### PR TITLE
Added - (void)observe:keyPath:initial:block:

### DIFF
--- a/FBKVOController/FBKVOController.h
+++ b/FBKVOController/FBKVOController.h
@@ -19,6 +19,15 @@ typedef void (^FBKVONotificationBlock)(id observer, id object, NSDictionary *cha
 
 
 /**
+ @abstract Block called on key-value change notification.
+ @param object The object changed.
+ @param keypath The keypath of the observer.
+ @param oldObject The previous assigned object to keypath.
+  @param newObject The new assigned object to keypath.
+ */
+typedef void (^FBKVONotificationChangeBlock)(id object, NSString * keyPath, id oldValue, id newValue);
+
+/**
  @abstract FBKVOController makes Key-Value Observing simpler and safer.
  @discussion FBKVOController adds support for handling key-value changes with blocks and custom actions, as well as the NSKeyValueObserving callback. Notification will never message a deallocated observer. Observer removal never throws exceptions, and observers are removed implicitely on controller deallocation. FBKVOController is also thread safe. When used in a concurrent environment, it protects observers from possible ressurection and avoids ensuing crash. The controller maintains a strong reference to objects observed.
  */
@@ -50,6 +59,16 @@ typedef void (^FBKVONotificationBlock)(id observer, id object, NSDictionary *cha
  @discussion On key-value change, the specified block is called. Inorder to avoid retain loops, the block must avoid referencing the KVO controller or an owner thereof. Observing an already observed object key path or nil results in no operation.
  */
 - (void)observe:(id)object keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(FBKVONotificationBlock)block;
+
+/**
+ @abstract Registers observer for key-value change notification.
+ @param object The object to observe.
+ @param keyPath The key path to observe.
+ @param initial The initial flag for the block options
+ @param block The block to execute on notification.
+ @discussion On key-value change, the specified block is called. Inorder to avoid retain loops, the block must avoid referencing the KVO controller or an owner thereof. Observing an already observed object key path or nil results in no operation.
+ */
+- (void)observe:(id)object keyPath:(NSString *)keyPath initial:(BOOL)initial block:(FBKVONotificationChangeBlock)block;
 
 /**
  @abstract Registers observer for key-value change notification.

--- a/FBKVOController/FBKVOController.m
+++ b/FBKVOController/FBKVOController.m
@@ -525,6 +525,16 @@ static NSDictionary *change_dictionary_init(id object, NSUInteger options, NSStr
   [self _observe:object info:info];
 }
 
+- (void)observe:(id)object keyPath:(NSString *)keyPath initial:(BOOL)initial block:(FBKVONotificationChangeBlock)block
+{
+  NSKeyValueObservingOptions options = NSKeyValueObservingOptionNew|NSKeyValueObservingOptionOld;
+  if(initial)  options |= NSKeyValueObservingOptionInitial;
+  
+  [self observe:object keyPath:keyPath options:options block:^(id observer, id object, NSDictionary *change) {
+    block(object, keyPath, change[NSKeyValueChangeOldKey], change[NSKeyValueChangeNewKey]);
+  }];
+}
+
 - (void)observe:(id)object keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options action:(SEL)action
 {
   NSAssert(0 != keyPath.length && NULL != action, @"missing required parameters observe:%@ keyPath:%@ action:%@", object, keyPath, NSStringFromSelector(action));


### PR DESCRIPTION
with block
void (^FBKVONotificationChangeBlock)(id object, NSString * keyPath, id oldValue, id newValue);

I was also thinking of adding an additional block-selector for an array of keyPaths. So you could share blocks for different keypaths. Something like; https://github.com/seivan/SHRACComparison#third-sample

Some thoughts about separating each 'pattern' with subspec.
So you'd have a subspec for block based, one for selectors and one for the old fashioned delegate. 
EDIT: Created an issue for this. 

I've signed the CLA.... sorta. 