### PR TITLE
testDeallocatedObserver fix for 32 bit simulator

### DIFF
--- a/FBKVOControllerTests/FBKVOControllerTests.m
+++ b/FBKVOControllerTests/FBKVOControllerTests.m
@@ -269,7 +269,7 @@ static NSKeyValueObservingOptions const optionsAll = optionsBasic | NSKeyValueOb
 {
   FBKVOTestCircle *circle = [FBKVOTestCircle circle];
   id<FBKVOTestObserving> observer = mockProtocol(@protocol(FBKVOTestObserving));
-  __attribute__((objc_precise_lifetime)) FBKVOController *controller = [FBKVOController controllerWithObserver:observer];
+  __attribute__((objc_precise_lifetime)) FBKVOController *controller = [[FBKVOController alloc] initWithObserver:observer];
   
   // add mock observer
   [controller observe:circle keyPath:radius options:optionsBasic action:@selector(propertyDidChange)];


### PR DESCRIPTION
The controller seems to be auto released on 32 bit and released directly
when the last reference is removed on 64 bit systems. This caused the
deallocated controller test to fail when run in the 32 bit simulator.
