### PR TITLE
Add NSObject category with a convenient, lazy loaded KVOController

### DIFF
--- a/FBKVOController/FBKVOController.h
+++ b/FBKVOController/FBKVOController.h
@@ -144,5 +144,6 @@ typedef void (^FBKVONotificationBlock)(id observer, id object, NSDictionary *cha
  @discussion This makes it convenient to simply create and forget a FBKVOController, and when this object gets dealloc'd, so will the associated controller and the observation info.
  */
 @property (nonatomic, strong) FBKVOController *KVOController;
+@property (nonatomic, strong) FBKVOController *KVOControllerNonRetaining;
 
 @end

--- a/FBKVOController/FBKVOController.m
+++ b/FBKVOController/FBKVOController.m
@@ -626,6 +626,7 @@ static NSString *describe_options(NSKeyValueObservingOptions options)
 #pragma mark NSObject Category -
 
 static void *NSObjectKVOControllerKey = &NSObjectKVOControllerKey;
+static void *NSObjectKVOControllerNonRetainingKey = &NSObjectKVOControllerNonRetainingKey;
 
 @implementation NSObject (FBKVOController)
 
@@ -645,6 +646,23 @@ static void *NSObjectKVOControllerKey = &NSObjectKVOControllerKey;
 - (void)setKVOController:(FBKVOController *)KVOController
 {
   objc_setAssociatedObject(self, NSObjectKVOControllerKey, KVOController, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (FBKVOController *)KVOControllerNonRetaining
+{
+  id controller = objc_getAssociatedObject(self, NSObjectKVOControllerNonRetainingKey);
+  
+  if (nil == controller) {
+    controller = [[FBKVOController alloc] initWithObserver:self retainObserved:NO];
+    self.KVOControllerNonRetaining = controller;
+  }
+  
+  return controller;
+}
+
+- (void)setKVOControllerNonRetaining:(FBKVOController *)KVOControllerNonRetaining
+{
+  objc_setAssociatedObject(self, NSObjectKVOControllerNonRetainingKey, KVOControllerNonRetaining, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 @end


### PR DESCRIPTION
Hi,

Since the functionality of this component is "core", and I would like to use it much as I would use the default KVO functionality (without instantiating anything myself), I added this `NSObject` category to take that off my hands, and make the entry level one line shorter.

I haven't updated the read me to reflect that, I could do that if you guys need that.

Cheers,
