### PR TITLE
Update Podspec with description and FBKVOController keyword

### DIFF
--- a/KVOController.podspec
+++ b/KVOController.podspec
@@ -5,6 +5,16 @@ Pod::Spec.new do |spec|
   spec.homepage     = 'https://github.com/facebook/KVOController'
   spec.authors      = { 'Kimon Tsinteris' => 'kimon@mac.com' }
   spec.summary      = 'Simple, modern, thread-safe key-value observing.'
+  spec.description  = <<-DESC
+                      KVOController builds on Cocoa's time-tested key-value observing implementation. It offers a simple, modern API, that is also thread safe.
+                      Benefits include:
+                      Notification using blocks, custom actions, or NSKeyValueObserving callback.
+                      No exceptions on observer removal.
+                      Implicit observer removal on controller dealloc.
+                      Thread-safety with special guards against observer resurrection.
+                      
+                      Single class: FBKVOController
+                      DESC
   spec.source       = { :git => 'https://github.com/facebook/KVOController.git', :tag => spec.version.to_s }
   spec.source_files = 'FBKVOController/*.{h,m}'
   spec.requires_arc = true


### PR DESCRIPTION
Added a description. Mostly just took the first paragraph from the README.
More importantly having the word `FBKVOController` in the description means CocoaPods searches of that term will find this pod.