### PR TITLE
Improve coverage; Demonstrate non-retaining controller bug with test

### DIFF
--- a/FBKVOController.xcodeproj/project.pbxproj
+++ b/FBKVOController.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		46B05A2E1A076AD70022AB70 /* NSObject+FBKVOController.m in Sources */ = {isa = PBXBuildFile; fileRef = 46B05A2D1A076AD70022AB70 /* NSObject+FBKVOController.m */; };
 		46B05A301A076CC40022AB70 /* NSObject+FBKVOController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 46B05A2F1A076ADD0022AB70 /* NSObject+FBKVOController.h */; };
 		C2F52F758CAD49A0B9569C07 /* libPods-FBKVOControllerTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CEF702BB5574A90B448BF09 /* libPods-FBKVOControllerTests.a */; };
+		DA350F251AE2B8C6001B2CCB /* NSObject+FBKVOControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA350F241AE2B8C6001B2CCB /* NSObject+FBKVOControllerTests.m */; };
 		EC8BB5AE18A5792D00EB2793 /* FBKVOTesting.m in Sources */ = {isa = PBXBuildFile; fileRef = EC8BB5AD18A5792D00EB2793 /* FBKVOTesting.m */; };
 		ECEA610218A49C620064AFF4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECEA610118A49C620064AFF4 /* Foundation.framework */; };
 		ECEA610718A49C620064AFF4 /* FBKVOController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ECEA610618A49C620064AFF4 /* FBKVOController.h */; };
@@ -74,6 +75,7 @@
 		46B05A2D1A076AD70022AB70 /* NSObject+FBKVOController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+FBKVOController.m"; sourceTree = "<group>"; };
 		46B05A2F1A076ADD0022AB70 /* NSObject+FBKVOController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+FBKVOController.h"; sourceTree = "<group>"; };
 		5CEF702BB5574A90B448BF09 /* libPods-FBKVOControllerTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FBKVOControllerTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA350F241AE2B8C6001B2CCB /* NSObject+FBKVOControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+FBKVOControllerTests.m"; sourceTree = "<group>"; };
 		EC8BB5AC18A5792D00EB2793 /* FBKVOTesting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBKVOTesting.h; sourceTree = "<group>"; };
 		EC8BB5AD18A5792D00EB2793 /* FBKVOTesting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBKVOTesting.m; sourceTree = "<group>"; };
 		EC8BB5B318A5A1EE00EB2793 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -187,6 +189,7 @@
 			isa = PBXGroup;
 			children = (
 				ECEA611D18A49C620064AFF4 /* FBKVOControllerTests.m */,
+				DA350F241AE2B8C6001B2CCB /* NSObject+FBKVOControllerTests.m */,
 				EC8BB5AC18A5792D00EB2793 /* FBKVOTesting.h */,
 				EC8BB5AD18A5792D00EB2793 /* FBKVOTesting.m */,
 				ECEA611818A49C620064AFF4 /* Supporting Files */,
@@ -357,6 +360,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ECEA611E18A49C620064AFF4 /* FBKVOControllerTests.m in Sources */,
+				DA350F251AE2B8C6001B2CCB /* NSObject+FBKVOControllerTests.m in Sources */,
 				EC8BB5AE18A5792D00EB2793 /* FBKVOTesting.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FBKVOControllerTests/FBKVOControllerTests.m
+++ b/FBKVOControllerTests/FBKVOControllerTests.m
@@ -311,10 +311,4 @@ static NSKeyValueObservingOptions const optionsAll = optionsBasic | NSKeyValueOb
   circle.radius = 1.0;
 }
 
-- (void)testTravisContinuousIntegrationHappyDance
-{
-  // happy dance
-  return;
-}
-
 @end

--- a/FBKVOControllerTests/FBKVOTesting.h
+++ b/FBKVOControllerTests/FBKVOTesting.h
@@ -19,6 +19,18 @@
 @end
 
 /**
+ This global boolean is set to YES whenever an instance of
+ FBKVOTestCircleDeallocating is deallocated.
+ */
+extern BOOL FBKVOTestCircleDeallocatingWasDeallocated;
+
+/**
+ Circle test object that sets some global state when it's deallocated.
+ */
+@interface FBKVOTestCircleDeallocating : FBKVOTestCircle
+@end
+
+/**
  Observer protocol for mocking.
  */
 @protocol FBKVOTestObserving <NSObject>

--- a/FBKVOControllerTests/FBKVOTesting.m
+++ b/FBKVOControllerTests/FBKVOTesting.m
@@ -23,6 +23,17 @@
 
 @end
 
+BOOL FBKVOTestCircleDeallocatingWasDeallocated = NO;
+
+@implementation FBKVOTestCircleDeallocating
+
+- (void)dealloc
+{
+  FBKVOTestCircleDeallocatingWasDeallocated = YES;
+}
+
+@end
+
 @implementation FBKVOTestObserver
 
 + (instancetype)observer

--- a/FBKVOControllerTests/NSObject+FBKVOControllerTests.m
+++ b/FBKVOControllerTests/NSObject+FBKVOControllerTests.m
@@ -1,0 +1,24 @@
+/**
+ Copyright (c) 2014-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <FBKVOController/NSObject+FBKVOController.h>
+
+@interface NSObject_FBKVOControllerTests : XCTestCase
+@end
+
+@implementation NSObject_FBKVOControllerTests
+
+- (void)testFBKVOControllerOnAnyObjectIsNotNil {
+  NSObject *object = [[NSObject alloc] init];
+  XCTAssertNotNil(object.KVOController);
+}
+
+@end

--- a/FBKVOControllerTests/NSObject+FBKVOControllerTests.m
+++ b/FBKVOControllerTests/NSObject+FBKVOControllerTests.m
@@ -24,7 +24,8 @@
   FBKVOTestCircleDeallocatingWasDeallocated = NO;
 }
 
-- (void)testFBKVOControllerOnAnyObjectIsNotNil {
+- (void)testFBKVOControllerOnAnyObjectIsNotNil
+{
   // Arrange: Begin observing an object using a non-retaining observer.
   NSObject *observer = [NSObject new];
   FBKVOTestCircleDeallocating *deallocating = [FBKVOTestCircleDeallocating circle];
@@ -39,7 +40,8 @@
                  @"The object should not have been deallocated because its observer was retaining.");
 }
 
-- (void)testFBKVOControllerNotRetainingOnAnyObjectIsNotNil {
+- (void)testFBKVOControllerNotRetainingOnAnyObjectIsNotNil
+{
   // Arrange: Begin observing an object using a non-retaining observer.
   NSObject *observer = [NSObject new];
   FBKVOTestCircleDeallocating *deallocating = [FBKVOTestCircleDeallocating circle];


### PR DESCRIPTION
Add a test case that demonstrates that non-retaining FBKVOControllers
trigger exceptions when the observed objects are deallocated. The tests do not pass on this commit.

---

It seems like non-retaining KVO controllers don't work, since an exception is thrown when the observed is deallocated. Am I missing something here? :tangerine: 