### PR TITLE
Added key path argument to callback block.

### DIFF
--- a/FBKVOController/FBKVOController.h
+++ b/FBKVOController/FBKVOController.h
@@ -13,9 +13,10 @@
  @abstract Block called on key-value change notification.
  @param observer The observer of the change.
  @param object The object changed.
+ @param keyPath The key path being observed on object.
  @param change The change dictionary.
  */
-typedef void (^FBKVONotificationBlock)(id observer, id object, NSDictionary *change);
+typedef void (^FBKVONotificationBlock)(id observer, id object, NSString* keyPath, NSDictionary *change);
 
 
 /**

--- a/FBKVOController/FBKVOController.m
+++ b/FBKVOController/FBKVOController.m
@@ -329,7 +329,7 @@ static NSString *describe_options(NSKeyValueObservingOptions options)
         
         // dispatch custom block or action, fall back to default action
         if (info->_block) {
-          info->_block(observer, object, change);
+          info->_block(observer, object, keyPath, change);
         } else if (info->_action) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"

--- a/FBKVOControllerTests/FBKVOControllerTests.m
+++ b/FBKVOControllerTests/FBKVOControllerTests.m
@@ -45,25 +45,29 @@ static NSKeyValueObservingOptions const optionsAll = optionsBasic | NSKeyValueOb
   __block NSUInteger blockCallCount = 0;
   __block id blockObserver = nil;
   __block id blockObject = nil;
+  __block NSString* blockKeyPath = nil;
   __block NSDictionary *blockChange = nil;
   
   // add mock observer
-  [controller observe:circle keyPath:radius options:optionsBasic block:^(id observer, id object, NSDictionary *change) {
+  [controller observe:circle keyPath:radius options:optionsBasic block:^(id observer, id object, NSString* keyPath, NSDictionary *change) {
     blockObserver = observer;
     blockObject = object;
     blockChange = change;
+    blockKeyPath = keyPath;
     blockCallCount++;
   }];
   
   XCTAssert(1 == blockCallCount, @"unexpected block call count:%lu expected:%d", (unsigned long)blockCallCount, 1);
   XCTAssert(blockObserver == observer, @"value:%@ expected:%@", blockObserver, observer);
   XCTAssert(blockObject == referenceObserver.lastObject, @"value:%@ expected:%@", blockObject, referenceObserver.lastObject);
+  XCTAssert(blockKeyPath == radius, @"value:%@ expected:%@", blockKeyPath, radius);
   XCTAssertEqualObjects(blockChange, referenceObserver.lastChange, @"value:%@ expected:%@", blockChange, referenceObserver.lastChange);
   
   circle.radius = 1.0;
   XCTAssert(2 == blockCallCount, @"unexpected block call count:%lu expected:%d", (unsigned long)blockCallCount, 2);
   XCTAssert(blockObserver == observer, @"value:%@ expected:%@", blockObserver, observer);
   XCTAssert(blockObject == referenceObserver.lastObject, @"value:%@ expected:%@", blockObject, referenceObserver.lastObject);
+  XCTAssert(blockKeyPath == radius, @"value:%@ expected:%@", blockKeyPath, radius);
   XCTAssertEqualObjects(blockChange, referenceObserver.lastChange, @"value:%@ expected:%@", blockChange, referenceObserver.lastChange);
   
   // cleanup


### PR DESCRIPTION
The key path was missing from the block arguments, making the observe:keyPaths:options:block message somewhat unusable. I've added the key path to the existing test, not sure if more tests are needed.