### PR TITLE
make it easier when a strong reference between controller and observe would create a retain loop

### DIFF
--- a/FBKVOController/FBKVOController.h
+++ b/FBKVOController/FBKVOController.h
@@ -36,7 +36,7 @@ typedef void (^FBKVONotificationBlock)(id observer, id object, NSDictionary *cha
  @param observer The object notified on key-value change. The specified observer must support weak references.
  @param retainObserved Flag indicating whether observed objects should be retained.
  @return The initialized KVO controller instance.
- @discussion Use retainObserved = NO when a strong reference between controller and observee would create a retain loop. When not retaining observees, special care must be taken to remove observation info prior to observee dealloc.
+ @discussion Use retainObserved = NO when a strong reference between controller and observee would create a retain loop. 
  */
 - (instancetype)initWithObserver:(id)observer retainObserved:(BOOL)retainObserved;
 

--- a/FBKVOController/FBKVOController.m
+++ b/FBKVOController/FBKVOController.m
@@ -365,7 +365,7 @@ static NSString *describe_options(NSKeyValueObservingOptions options)
   self = [super init];
   if (nil != self) {
     _observer = observer;
-    NSPointerFunctionsOptions keyOptions = retainObserved ? NSPointerFunctionsStrongMemory|NSPointerFunctionsObjectPointerPersonality : NSPointerFunctionsWeakMemory|NSPointerFunctionsObjectPointerPersonality;
+    NSPointerFunctionsOptions keyOptions = retainObserved ? NSPointerFunctionsStrongMemory|NSPointerFunctionsObjectPointerPersonality : NSPointerFunctionsOpaqueMemory|NSPointerFunctionsObjectPointerPersonality;
     _objectInfosMap = [[NSMapTable alloc] initWithKeyOptions:keyOptions valueOptions:NSPointerFunctionsStrongMemory|NSPointerFunctionsObjectPersonality capacity:0];
     _lock = OS_SPINLOCK_INIT;
   }


### PR DESCRIPTION
I'm trying to solve #48

Observing `self` is frequently needed in our project. It will be nice if we don't need to call `unobserveAll` prior to `dealloc`.

The reason for the original problem is: A retain loop is created when we set `NSMapTable`'s keys with the `NSPointerFunctionsStrongMemory` option (when `self` observes `self`), but it causes a crash when we set `NSMapTable`'s keys with the `NSPointerFunctionsWeakMemory` option since there is no chance to remove the `keyPath` from the observer as a weak property is set to nil in dealloc.

I tried to find a way to set the key option to `assign`, and I found `NSPointerFunctionsOpaqueMemory` in [Apple's documentation](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSPointerFunctions_Class/index.html#//apple_ref/doc/constant_group/Memory_and_Personality_Options):

>Take no action when pointers are deleted.

>This is usually the preferred memory option for holding arbitrary pointers.

I have tested this and I'm sure this is what is needed.

Thanks a lot!