### PR TITLE
Do not log a warning when observing an already observed object key path

### DIFF
--- a/FBKVOController/FBKVOController.m
+++ b/FBKVOController/FBKVOController.m
@@ -424,7 +424,7 @@ static NSString *describe_options(NSKeyValueObservingOptions options)
   // check for info existence
   _FBKVOInfo *existingInfo = [infos member:info];
   if (nil != existingInfo) {
-    NSLog(@"observation info already exists %@", existingInfo);
+    // observation info already exists; do not observe it again
     
     // unlock and return
     OSSpinLockUnlock(&_lock);


### PR DESCRIPTION
As mentioned in the documentation, observing an already observed object key path using `- observe:keyPaths:...` methods should "result in no operation". However, the current implementation logs a warning/info in that case. Since "observing an already observed object key path" is not a misuse of the API, I think the warning is unnecessary. I am relying on the aforementioned behavior in one of my project and found the NSLog messages a little bit annoying.

This is also the only occurrence of NSLog in the whole project.