### PR TITLE
Update badge graphics and coverage service in README.

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -1,5 +1,0 @@
-ci_service: travis_ci
-coverage_service: coveralls
-xcodeproj: FBKVOController.xcodeproj
-source_directory: FBKVOController
-

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # [KVOController](https://github.com/facebook/KVOController)
-[![Build Status](https://travis-ci.org/facebook/KVOController.png?branch=master)](https://travis-ci.org/facebook/KVOController)
-[![Coverage Status](https://coveralls.io/repos/facebook/KVOController/badge.svg?branch=master)](https://coveralls.io/r/facebook/KVOController?branch=master)
-[![Version](https://cocoapod-badges.herokuapp.com/v/KVOController/badge.png)](http://cocoadocs.org/docsets/KVOController)
-[![Platform](https://cocoapod-badges.herokuapp.com/p/KVOController/badge.png)](http://cocoadocs.org/docsets/KVOController)
+[![Build Status](https://img.shields.io/travis/facebook/KVOController/master.svg?style=flat)](https://travis-ci.org/facebook/KVOController)
+[![Coverage Status](https://img.shields.io/codecov/c/github/facebook/KVOController/master.svg)](https://codecov.io/github/facebook/KVOController)
+[![Version](https://img.shields.io/cocoapods/v/KVOController.svg?style=flat)](http://cocoadocs.org/docsets/KVOController)
+[![Platform](https://img.shields.io/cocoapods/p/KVOController.svg?style=flat)](http://cocoadocs.org/docsets/KVOController)
 
 Key-value observing is a particularly useful technique for communicating between layers in a Model-View-Controller application. KVOController builds on Cocoa's time-tested key-value observing implementation. It offers a simple, modern API, that is also thread safe. Benefits include:
 


### PR DESCRIPTION
Use badges from img.shields.io, since it's pretty much a standard at this point, also much faster to update, as well as it's an `svg`, which I guess makes it better in some sense?
Most important change - use badge from codecov for code coverage.