### PR TITLE
Fixed deallocation crash while object is self-observer

### DIFF
--- a/FBKVOController/FBKVOController.m
+++ b/FBKVOController/FBKVOController.m
@@ -355,7 +355,33 @@ static NSString *describe_options(NSKeyValueObservingOptions options)
 
 @end
 
+#pragma mark FBKVOControllerObserverHandler -
+
+@interface FBKVOControllerObserverHandler : NSObject
+
+@property (nullable, atomic, assign, readonly) id theObject;
+
+@end
+
+@implementation FBKVOControllerObserverHandler
+
+- (instancetype)initWithTheObject:(id)theObject
+{
+  if (self = [super init]) {
+    _theObject = theObject;
+  }
+  return self;
+}
+
+@end
+
 #pragma mark FBKVOController -
+
+@interface FBKVOController ()
+
+@property (nullable, atomic, strong) FBKVOControllerObserverHandler *observerHandler;
+
+@end
 
 @implementation FBKVOController
 {
@@ -531,6 +557,14 @@ static NSString *describe_options(NSKeyValueObservingOptions options)
     return;
   }
   
+  if (object == self.observer) {
+    if (self.observerHandler == nil) {
+      self.observerHandler = [[FBKVOControllerObserverHandler alloc] initWithTheObject:self.observer];
+    }
+    keyPath = [@[NSStringFromSelector(@selector(theObject)), keyPath] componentsJoinedByString:@"."];
+    object = self.observerHandler;
+  }
+  
   // create info
   _FBKVOInfo *info = [[_FBKVOInfo alloc] initWithController:self keyPath:keyPath options:options block:block];
   
@@ -559,6 +593,14 @@ static NSString *describe_options(NSKeyValueObservingOptions options)
     return;
   }
   
+  if (object == self.observer) {
+    if (self.observerHandler == nil) {
+      self.observerHandler = [[FBKVOControllerObserverHandler alloc] initWithTheObject:self.observer];
+    }
+    keyPath = [@[NSStringFromSelector(@selector(theObject)), keyPath] componentsJoinedByString:@"."];
+    object = self.observerHandler;
+  }
+  
   // create info
   _FBKVOInfo *info = [[_FBKVOInfo alloc] initWithController:self keyPath:keyPath options:options action:action];
   
@@ -584,6 +626,14 @@ static NSString *describe_options(NSKeyValueObservingOptions options)
   NSAssert(0 != keyPath.length, @"missing required parameters observe:%@ keyPath:%@", object, keyPath);
   if (nil == object || 0 == keyPath.length) {
     return;
+  }
+  
+  if (object == self.observer) {
+    if (self.observerHandler == nil) {
+      self.observerHandler = [[FBKVOControllerObserverHandler alloc] initWithTheObject:self.observer];
+    }
+    keyPath = [@[NSStringFromSelector(@selector(theObject)), keyPath] componentsJoinedByString:@"."];
+    object = self.observerHandler;
   }
   
   // create info

--- a/FBKVOController/FBKVOController.m
+++ b/FBKVOController/FBKVOController.m
@@ -657,6 +657,11 @@ static NSString *describe_options(NSKeyValueObservingOptions options)
 
 - (void)unobserve:(nullable id)object keyPath:(NSString *)keyPath
 {
+  if (object == self.observer) {
+    keyPath = [keyPath substringFromIndex:NSStringFromSelector(@selector(theObject)).length + 1];
+    object = self.observerHandler;
+  }
+  
   // create representative info
   _FBKVOInfo *info = [[_FBKVOInfo alloc] initWithController:self keyPath:keyPath];
   
@@ -668,6 +673,10 @@ static NSString *describe_options(NSKeyValueObservingOptions options)
 {
   if (nil == object) {
     return;
+  }
+  
+  if (object == self.observer) {
+    object = self.observerHandler;
   }
   
   [self _unobserve:object];

--- a/FBKVOControllerTests/FBKVOControllerTests.m
+++ b/FBKVOControllerTests/FBKVOControllerTests.m
@@ -477,6 +477,19 @@ static NSKeyValueObservingOptions const optionsAll = optionsBasic | NSKeyValueOb
   circle.radius = 1.0;
 }
 
+- (void)testSelfObserverToUnobserve
+{
+  __weak FBKVOTestCircle *weakCircle;
+  
+  @autoreleasepool {
+    FBKVOTestCircle *circle = [FBKVOTestCircle circle];
+    [circle.KVOControllerNonRetaining observe:circle keyPath:radius options:optionsBasic action:@selector(self)];
+    weakCircle = circle;
+  }
+  
+  XCTAssertNil(weakCircle, @"");
+}
+
 - (void)testTravisContinuousIntegrationHappyDance
 {
   // happy dance


### PR DESCRIPTION
This is just my try to fix this bug: https://github.com/facebook/KVOController/issues/48

I have added a simple test in first commit to demonstrate problem solved in this PR.

I just wanna use KVOController this way without any crashes and retain cycles:
```objective-c
- (instancetype)initWithFrame:(CGRect)frame
{
    if (self = [super initWithFrame:frame]) {

        [self.KVOControllerNonRetaining observe:self keyPath:@keypath(self.viewModel.title) options:(NSKeyValueObservingOptionInitial|NSKeyValueObservingOptionNew) block:^(id  _Nullable observer, id  _Nonnull object, NSDictionary<NSString *,id> * _Nonnull change) {
            self.titleLabel.text = self.viewModel.title;
        }];

        [self.KVOControllerNonRetaining observe:self keyPath:@keypath(self.viewModel.value) options:(NSKeyValueObservingOptionInitial|NSKeyValueObservingOptionNew) block:^(id  _Nullable observer, id  _Nonnull object, NSDictionary<NSString *,id> * _Nonnull change) {
            self.valueLabel.text = [NSString stringWithFormat:@"Value = %f", self.viewModel.value];
        }];

    }
    return self;
}
```