### PR TITLE
Add tvOS support to podspec.

### DIFF
--- a/KVOController.podspec
+++ b/KVOController.podspec
@@ -21,5 +21,6 @@ Pod::Spec.new do |spec|
 
   spec.ios.deployment_target = '6.0'
   spec.osx.deployment_target = '10.7'
-  spec.watchos.deployment_target = "2.0"
+  spec.tvos.deployment_target = '9.0'
+  spec.watchos.deployment_target = '2.0'
 end


### PR DESCRIPTION
Looks like this explicit setting was missing.
This will make it finally usable on tvOS via CocoaPods.