### PR TITLE
Make observer property on FBKVOController nonatomic.

### DIFF
--- a/FBKVOController/FBKVOController.h
+++ b/FBKVOController/FBKVOController.h
@@ -77,8 +77,10 @@ typedef void (^FBKVONotificationBlock)(id _Nullable observer, id object, NSDicti
  */
 - (instancetype)initWithObserver:(nullable id)observer;
 
-/// The observer notified on key-value change. Specified on initialization.
-@property (nullable, atomic, weak, readonly) id observer;
+/**
+ The observer notified on key-value change. Specified on initialization.
+ */
+@property (nullable, nonatomic, weak, readonly) id observer;
 
 /**
  @abstract Registers observer for key-value change notification.


### PR DESCRIPTION
Since this is `readonly` - it doesn't matter if it's atomic or not, so change it to the cheaper getter that doesn't acquire the lock.