### PR TITLE
Modernizing the change dictionary to use the new string enum NSKeyValueChangeKey

### DIFF
--- a/FBKVOController/FBKVOController.h
+++ b/FBKVOController/FBKVOController.h
@@ -50,7 +50,7 @@ extern NSString *const FBKVONotificationKeyPathKey;
  @param object The object changed.
  @param change The change dictionary which also includes @c FBKVONotificationKeyPathKey
  */
-typedef void (^FBKVONotificationBlock)(id _Nullable observer, id object, NSDictionary<NSString *, id> *change);
+typedef void (^FBKVONotificationBlock)(id _Nullable observer, id object, NSDictionary<NSKeyValueChangeKey, id> *change);
 
 /**
  @abstract FBKVOController makes Key-Value Observing simpler and safer.

--- a/FBKVOController/FBKVOController.m
+++ b/FBKVOController/FBKVOController.m
@@ -348,7 +348,7 @@ NSString *const FBKVONotificationKeyPathKey = @"FBKVONotificationKeyPathKey";
 
 - (void)observeValueForKeyPath:(nullable NSString *)keyPath
                       ofObject:(nullable id)object
-                        change:(nullable NSDictionary<NSString *, id> *)change
+                        change:(nullable NSDictionary<NSKeyValueChangeKey, id> *)change
                        context:(nullable void *)context
 {
   NSAssert(context, @"missing context keyPath:%@ object:%@ change:%@", keyPath, object, change);
@@ -374,7 +374,7 @@ NSString *const FBKVONotificationKeyPathKey = @"FBKVONotificationKeyPathKey";
 
         // dispatch custom block or action, fall back to default action
         if (info->_block) {
-          NSDictionary<NSString *, id> *changeWithKeyPath = change;
+          NSDictionary<NSKeyValueChangeKey, id> *changeWithKeyPath = change;
           // add the keyPath to the change dictionary for clarity when mulitple keyPaths are being observed
           if (keyPath) {
             NSMutableDictionary<NSString *, id> *mChange = [NSMutableDictionary dictionaryWithObject:keyPath forKey:FBKVONotificationKeyPathKey];


### PR DESCRIPTION
This way it would help Swift bridging to use an enum for the change dictionary.