### PR TITLE
Fix retain cycle in Swift example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ kvoController.observe(viewModel,
                       keyPath: "listsDidChange",
                       options: [.new, .initial]) { (viewController, viewModel, change) in
     
-  self.taskListsTableView.reloadData()
+  viewController.taskListsTableView.reloadData()
 }
 ```
 


### PR DESCRIPTION
Swift example references self from the observer block, which creates a retain cycle.